### PR TITLE
Update validate-version.sh

### DIFF
--- a/bin/validate-version.sh
+++ b/bin/validate-version.sh
@@ -8,10 +8,10 @@ PACKAGE_LOCK_VERSION=$(node -p "require('./package-lock.json').version")
 # Get highest tag published on GitHub
 HIGHEST_GIT_TAG=$(git tag --list 2>/dev/null | sort -V | tail -n1 2>/dev/null | sed 's/v//g')
 
-if [ $CURRENT_VERSION != $PACKAGE_LOCK_VERSION ]; then
+if [ "$CURRENT_VERSION" != "$PACKAGE_LOCK_VERSION" ]; then
   echo "Version $CURRENT_VERSION in package.json doesn't match version $PACKAGE_LOCK_VERSION in package-lock.json."
   exit 1
-elif [ $CURRENT_VERSION == $HIGHEST_GIT_TAG ]; then
+elif [ "$CURRENT_VERSION" == "$HIGHEST_GIT_TAG" ]; then
   echo "Git tag $HIGHEST_GIT_TAG already exists. Check you have updated the version in package.json correctly."
   exit 1
 fi


### PR DESCRIPTION
Fix issue from https://github.com/LandRegistry/hmlr-frontend/actions/runs/6811554847/job/18522135023 with unescaped variables