### PR TITLE
Update govuk-frontend to 5.4.0

### DIFF
--- a/.storybook/storybook.scss
+++ b/.storybook/storybook.scss
@@ -1,2 +1,2 @@
-$govuk-assets-path: "/node_modules/govuk-frontend/govuk/assets/";
+$govuk-assets-path: "/node_modules/govuk-frontend/dist/govuk/assets/";
 $hmlr-assets-path: "/src/hmlr/assets/";

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased] - yyyy-mm-dd
 
+### Changed
+- Updated `govuk-frontend` to `5.4.0`
+- Updated js/css/assets import paths
+
 ## [1.4.0] - 2024-02-21
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hmlr/frontend",
-  "version": "2.0.0",
+  "version": "1.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@hmlr/frontend",
-      "version": "2.0.0",
+      "version": "1.5.0",
       "license": "MIT",
       "dependencies": {
         "govuk-frontend": "5.4.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@hmlr/frontend",
-  "version": "1.4.0",
+  "version": "2.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@hmlr/frontend",
-      "version": "1.4.0",
+      "version": "2.0.0",
       "license": "MIT",
       "dependencies": {
-        "govuk-frontend": "4.8.0"
+        "govuk-frontend": "5.4.0"
       },
       "devDependencies": {
         "@babel/core": "^7.23.9",
@@ -15624,9 +15624,9 @@
       }
     },
     "node_modules/govuk-frontend": {
-      "version": "4.8.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.8.0.tgz",
-      "integrity": "sha512-NOmPJxL8IYq1HSNHYKx9XY2LLTxuwb+IFASiGQO4sgJ8K7AG66SlSeqARrcetevV8zOf+i1z+MbJJ2O7//OxAw==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-5.4.0.tgz",
+      "integrity": "sha512-F3YwQYrYQqIPfNxsoph6O78Ey1unCB6cy6omx8KeWY9G504lWZFBSIaiUCma1jNLw9bOUU7Ui+tXG09jjqy0Mw==",
       "engines": {
         "node": ">= 4.2.0"
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hmlr/frontend",
-  "version": "2.0.0",
+  "version": "1.5.0",
   "description": "HM Land Registry frontend styles",
   "scripts": {
     "start": "start-storybook -p 6006",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hmlr/frontend",
-  "version": "1.4.0",
+  "version": "2.0.0",
   "description": "HM Land Registry frontend styles",
   "scripts": {
     "start": "start-storybook -p 6006",
@@ -46,7 +46,7 @@
   },
   "homepage": "https://github.com/LandRegistry/hmlr-frontend#readme",
   "dependencies": {
-    "govuk-frontend": "4.8.0"
+    "govuk-frontend": "5.4.0"
   },
   "devDependencies": {
     "@babel/core": "^7.23.9",

--- a/src/hmlr/_base.scss
+++ b/src/hmlr/_base.scss
@@ -1,7 +1,7 @@
 $govuk-include-default-font-face: false;
-$govuk-assets-path: "/govuk-frontend/govuk/assets/" !default;
+$govuk-assets-path: "/govuk-frontend/dist/govuk/assets/" !default;
 
 @import "settings/all";
 @import "tools/all";
 
-@import "node_modules/govuk-frontend/govuk/base.scss";
+@import "node_modules/govuk-frontend/dist/govuk/base.scss";

--- a/src/hmlr/all.scss
+++ b/src/hmlr/all.scss
@@ -6,7 +6,7 @@
 // before we import our ones so we can be
 // ensured that the version of GovUK used
 // is the correct one
-@import "node_modules/govuk-frontend/govuk/all";
+@import "node_modules/govuk-frontend/dist/govuk/all";
 
 // ...and then let us import all our HMLR
 // components

--- a/tasks/test-fixtures.js
+++ b/tasks/test-fixtures.js
@@ -24,7 +24,7 @@ glob(`${componentsDirectory}*${componentFixturesFile}`, (e, optionsFiles) => {
     const componentNunjucks = require(`../${componentsDirectory}${component}/template.njk`);
     const componentNunjucksAliased = componentNunjucks.replace(
       '{% include "govuk/',
-      '{% include "node_modules/govuk-frontend/govuk/'
+      '{% include "node_modules/govuk-frontend/dist/govuk/'
     );
     const failedFixtures = componentFixtures.fixtures.filter((fixture) => {
       const result = nunjucks

--- a/tasks/update-fixtures.js
+++ b/tasks/update-fixtures.js
@@ -24,7 +24,7 @@ glob(`${componentsDirectory}*${componentFixturesFile}`, (e, optionsFiles) => {
     const componentNunjucks = require(`../${componentsDirectory}${component}/template.njk`);
     const componentNunjucksAliased = componentNunjucks.replace(
       '{% include "govuk/',
-      '{% include "node_modules/govuk-frontend/govuk/'
+      '{% include "node_modules/govuk-frontend/dist/govuk/'
     );
 
     const newComponentFixtures = {


### PR DESCRIPTION
Changes in this MR:
* Update version of hmlr-frontend to 1.5.0
* Update `govuk-frontend` to version 5.4.0
* Updates the import locations for JS/CSS/Assets described here: https://github.com/alphagov/govuk-frontend/releases/tag/v5.0.0

See https://github.com/alphagov/govuk-frontend/releases for the full changelogs for 5.0.0-5.4.0.

_N.B._: I have updated the changelog, but left the changes in "unreleased", as I was unsure if release candidate versions would be needed